### PR TITLE
Need --shell-escape on gentoo (texlive-2017) for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,5 @@ TARGET = unix-cheat-sheet.pdf
 all: $(TARGET)
 
 %.pdf: %.tex
-	$(LATEXMK) $(LATEXMKFLAGS) -pdflatex="$(LATEX) $(LATEXFLAGS) %O %S" \
+	$(LATEXMK) --shell-escape $(LATEXMKFLAGS) -pdflatex="$(LATEX) $(LATEXFLAGS) %O %S" \
 		-pdf $<

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for creating a PDF from a LaTeX project
 LATEX = lualatex
-LATEXFLAGS = -halt-on-error -no-shell-escape
+LATEXFLAGS = -halt-on-error --shell-escape
 LATEXMK = latexmk
 LATEXMKFLAGS = -f
 TARGET = unix-cheat-sheet.pdf

--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,4 @@ TARGET = unix-cheat-sheet.pdf
 all: $(TARGET)
 
 %.pdf: %.tex
-	$(LATEXMK) --shell-escape $(LATEXMKFLAGS) -pdflatex="$(LATEX) $(LATEXFLAGS) %O %S" \
-		-pdf $<
+	$(LATEXMK) --shell-escape $(LATEXMKFLAGS) -pdf $<

--- a/unix-cheat-sheet.tex
+++ b/unix-cheat-sheet.tex
@@ -3,7 +3,6 @@
 \usepackage[landscape, margin=1cm]{geometry}
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
-\usepackage{fontspec}
 \usepackage[english]{babel}
 \usepackage{multicol}
 \usepackage[os=win]{menukeys}
@@ -11,9 +10,6 @@
 \usepackage{changepage}
 \usepackage{titlesec}
 \usepackage{enumitem}
-
-\setmainfont{Cantarell}
-\setmonofont{DejaVu Sans Mono}
 
 \pagenumbering{gobble}
 \setlength{\parindent}{0pt}


### PR DESCRIPTION
The tex will not compile without shell-escape. Fails with following message:

```
*geometry* driver: auto-detecting
*geometry* detected driver: pdftex
ABD: EveryShipout initializing macros
(/usr/share/texmf-dist/tex/context/base/mkii/supp-pdf.mkii
[Loading MPS to PDF converter (version 2006.09.02).]
) (/usr/share/texmf-dist/tex/latex/oberdiek/epstopdf-base.sty
(/usr/share/texmf-dist/tex/latex/oberdiek/grfext.sty
(/usr/share/texmf-dist/tex/generic/oberdiek/kvdefinekeys.sty))
! Missing number, treated as zero.
<to be read again> 
\relax 
l.178     \ifnum\pdf@shellescape
                              >0 %
 842 words of node memory still in use:
   10 hlist, 9 rule, 1 dir, 49 attribute, 55 glue_spec, 49 attribute_list, 3 if
_stack, 6 write, 16 pdf_literal, 17 pdf_colorstack nodes
   avail lists: 2:7,3:1,4:1,5:7,7:6,8:3,9:1
!  ==> Fatal error occurred, no output PDF file produced!
Transcript written on unix-cheat-sheet.log.
=== TeX engine is 'LuaTeX'

```